### PR TITLE
Generalize pip command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,5 +3,5 @@ echo "Installing libraries"
 sudo apt-get update
 sudo apt-get install gcc-avr binutils-avr gdb-avr avr-libc avrdude python3 python3-pip
 echo "Installing python dependencies"
-sudo pip3 install -r requirements.txt
+sudo python3 -m pip install -r requirements.txt
 echo "Writing directory shortcuts"


### PR DESCRIPTION
This will work on computers (like mine) who don't have pip3 installed but do have Python 3 installed. In my case, pip3 isn't an executable command, and running pip uses Python 2. My pull request fixes this issue for anyone else who encounters it and doesn't change functionality for the cases where pip3 works.