### PR TITLE
Add Ansible playbook for AVR setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 MKV-Code
 
 ## Getting Libraries
+
+Before you can compile/flash boards, you will need to install some AVR libraries
+and a configuration file on your system. There are two methods for doing this:
+with an Ansible playbook or with shell scripts.
+
+### Ansible Setup
+
+The Ansible playbook in `packages.yml` can be used to install the libraries and
+configuration you need. The playbook is *idempotent*, which means that you can
+run it as many times as you want and it will generally not repeat steps that it
+has already done on your system.
+
+To get started, you will need to install Ansible on your system:
+
+```bash
+$ sudo apt install ansible
+```
+
+Then, you need to run the Ansible playbook **from this directory** like this:
+
+```bash
+$ ansible-playbook -K packages.yml
+```
+
+### Shell Script Setup
+
+Note that this method is an alternative to the above, so you only need to do one
+of them. If you have already run the Ansible playbook, you can skip this
+section.
+
 First run the `setup.sh` script to get all the defualt AVR libraries.
 ```bash
 $ sudo bash setup.sh

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,41 @@
+# Install apt and pip packages necessary to build everything else.
+# You must run this playbook from THIS DIRECTORY, using this command:
+#
+#   $ ansible-playbook -K packages.yml
+#
+# You will be prompted for your sudo password.
+---
+- hosts: localhost
+  tasks:
+  - name: Install required packages used throughout the setup process
+    # You need sudo to install via apt.
+    become: yes
+    become_method: sudo
+    apt:
+      force_apt_get: yes
+      # Update apt if it's been more than an hour since the last update
+      cache_valid_time: 3600
+      pkg:
+        - gcc-avr
+        - binutils-avr
+        - gdb-avr
+        - avr-libc
+        - avrdude
+        - python3
+        - python3-pip
+  - name: Get current working directory
+    shell: pwd
+    register: working_directory
+  - name: Install Python dependencies
+    pip:
+      executable: pip3
+      # Read the requirements.txt file in this directory
+      requirements: "{{ working_directory.stdout }}/requirements.txt"
+  - name: Copy AVRDUDE configuration to home directory
+    copy:
+      src: .avrdude
+      dest: "{{ ansible_env.HOME }}"
+      # To prevent updates to .avrdude from overwriting an existing
+      # configuration, uncomment the following line.
+      #force: no
+


### PR DESCRIPTION
Add an Ansible playbook which installs the necessary AVR libraries using
apt and pip, and copies the AVRDUDE configuration to the user's home
directory. Also add corresponding instructions in the README for how to
run the Ansible playbook.

Using an Ansible playbook is useful for two reasons: (1) it is
idempotent, which means that it can be run multiple times without
repeating unnecessary steps (and potentially breaking some
configurations), and (2) it can be easily modified to run on remote
machines, which may be helpful in the future.

The current Ansible playbook can only run locally, and must be run from
the repository root directory. If necessary, this can be modified in the
future.